### PR TITLE
spkprodukt 23660: Oppdatering av tester.

### DIFF
--- a/src/test/kotlin/no/spk/panda/orkestrering/utforsker/rutiner/ValiderAktiveRutinefilerTest.kt
+++ b/src/test/kotlin/no/spk/panda/orkestrering/utforsker/rutiner/ValiderAktiveRutinefilerTest.kt
@@ -157,7 +157,7 @@ class ValiderAktiveRutinefilerTest {
     }
 
     private fun systemkorreksjonMaler(): Stream<File> {
-        val katalog = File("maler/systemkorreksjon")
+        val katalog = File("maler/fakturering/systemkorreksjon")
         return hentAlleJsonFiler(katalog).stream()
     }
 }

--- a/src/test/resources/skjemavalidering/rutinefilSkjema.json
+++ b/src/test/resources/skjemavalidering/rutinefilSkjema.json
@@ -84,7 +84,7 @@
     "variabler": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "type": ["string", "array"]
       }
     },
     "operasjoner": {


### PR DESCRIPTION
- Med ny forHver handling som bruker variabel av type liste, oppdateres rutinefilskjema for å støtte både strenger og arrays.
- Katalog for systemkorreksjon-maler endres til å peke på riktig mappeområde