### PR TITLE
SPKPRODUKT-26050: Endrer rutinefiler for premieprognose as asa.

### DIFF
--- a/maler/premieprognose/premieprognose_as_asa.json
+++ b/maler/premieprognose/premieprognose_as_asa.json
@@ -156,6 +156,11 @@
           "handling": "gruppe",
           "gruppeAv": [
             {
+              "handling": "kopier_arkivert_grunnlagsdata_fra_aktuar_til_pa_res_ba_01",
+              "versjon": "${reserveberegningGrunnlagsdataAktuarVersjon}",
+              "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
               "navn": "panda_reserveberegning",
               "handling": "gruppe",
               "gruppeAv": [

--- a/maler/premieprognose/premieprognose_as_asa.json
+++ b/maler/premieprognose/premieprognose_as_asa.json
@@ -115,345 +115,402 @@
       ]
     },
     {
-      "navn": "manipuler prognosedata",
+      "navn": "Første kjøring for å utlede målytelse fra reserveberegning",
       "handling": "gruppe",
       "gruppeAv": [
         {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_pre_ba_01"
-        },
-        {
-          "handling": "kopier_grunnlagsdata_fra_arkiv_til_batch",
-          "fraGrunnlagsdataMappe": "${fraGrunnlagsdataMappe}",
-          "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "fraBatch": "pa_res_ba_02",
-          "tilBatch": "pa_pre_ba_01"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${avtalelisteChecksum}",
-          "prognoseVersjon": "avtaleliste",
-          "batch": "pa_pre_ba_01"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_ny_avtale",
-          "prognoseVersjon": "${opprettNyAvtaleChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettNyAvtaleInstruksjon}"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_avtalebytte",
-          "prognoseVersjon": "${opprettAvtalebytteChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettAvtalebytteInstruksjon}"
-
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_avtalebytte_medlem",
-          "prognoseVersjon": "${opprettAvtalebytteMedlemChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettAvtalebytteMedlemInstruksjon}"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_sluttmelding",
-          "prognoseVersjon": "${opprettSluttmeldingChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettSluttmeldingInstruksjon}"
-        },
-        {
-          "handling": "pa_pre_ba_01",
-          "manipulatorer": "${manipulatorer}"
-        },
-        {
-          "handling": "kopier_filer_fra_pa_pre_ba_01_til_pa_res_ba_01",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        }
-      ]
-    },
-    {
-      "navn": "pa_res_ba_01 produser kontoføringer og administrasjonspremieunderlag",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_arkivert_grunnlagsdata_fra_aktuar_til_pa_res_ba_01",
-          "versjon": "${reserveberegningGrunnlagsdataAktuarVersjon}",
-          "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "navn": "panda_reserveberegning",
+          "navn": "manipuler prognosedata",
           "handling": "gruppe",
           "gruppeAv": [
             {
-              "handling": "pa_res_ba_01",
-              "modus": "panda_reserveberegning",
-              "sisteFremskrivingsdato": "${fremskrivingsDato}",
-              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-              "rettighet": "panda_veldig_forenkla_rettighet",
-              "premieprognose": {
-                "konverteringsår": "${premieprognoseKonvertingsår}",
-                "fremskrivingsfrekvens": "År"
-              }
+              "handling": "kopier_grunnlagsdata_fra_arkiv_til_batch",
+              "fraGrunnlagsdataMappe": "${fraGrunnlagsdataMappe}",
+              "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "fraBatch": "pa_res_ba_02",
+              "tilBatch": "pa_pre_ba_01"
             },
             {
-              "handling": "kopier_filer_fra_batch_til_batch",
-              "fraBatch": "pa_res_ba_01",
-              "tilBatch": "pa_fak_ba_13",
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${avtalelisteChecksum}",
+              "prognoseVersjon": "avtaleliste",
+              "batch": "pa_pre_ba_01"
+            },
+            {
+              "handling": "pa_pre_ba_01",
+              "manipulatorer": [
+                {
+                  "navn": "filtrer_medlemsbestand",
+                  "fraFil": "avtaleliste_hbf_as_asa.csv"
+                }
+              ]
+            },
+            {
+              "handling": "kopier_filer_fra_pa_pre_ba_01_til_pa_res_ba_01",
               "grunnlagsdataMappe": "${grunnlagsdataMappe}"
             }
           ]
         },
         {
-          "navn": "panda_administrasjonspremieunderlag",
+          "navn": "pa_res_ba_01 produser kontoføringer",
           "handling": "gruppe",
           "gruppeAv": [
             {
-              "handling": "pa_res_ba_01",
-              "modus": "panda_administrasjonspremieunderlag",
-              "sisteFremskrivingsdato": "${fremskrivingsDato}",
+              "navn": "panda_reserveberegning",
+              "handling": "gruppe",
+              "gruppeAv": [
+                {
+                  "handling": "pa_res_ba_01",
+                  "modus": "panda_reserveberegning",
+                  "sisteFremskrivingsdato": "${fremskrivingsDato}",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+                  "rettighet": "panda_veldig_forenkla_rettighet",
+                  "premieprognose": {
+                    "konverteringsår": "${premieprognoseKonvertingsår}",
+                    "fremskrivingsfrekvens": "År"
+                  }
+                },
+                {
+                  "handling": "legg_kontofoering_i_medlemsdata_for_manipulering",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+                },
+                {
+                  "handling": "rydd_grunnlagsdata_for_batch",
+                  "batch": "pa_res_ba_01"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "navn": "Andre kjøring for premieprognoser for AS/ASA",
+      "handling": "gruppe",
+      "gruppeAv": [
+        {
+          "navn": "manipuler prognosedata",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_ny_avtale",
+              "prognoseVersjon": "${opprettNyAvtaleChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettNyAvtaleInstruksjon}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_avtalebytte",
+              "prognoseVersjon": "${opprettAvtalebytteChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettAvtalebytteInstruksjon}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_avtalebytte_medlem",
+              "prognoseVersjon": "${opprettAvtalebytteMedlemChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettAvtalebytteMedlemInstruksjon}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_sluttmelding",
+              "prognoseVersjon": "${opprettSluttmeldingChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettSluttmeldingInstruksjon}"
+            },
+            {
+              "handling": "pa_pre_ba_01",
+              "manipulatorer": "${manipulatorer}"
+            },
+            {
+              "handling": "kopier_filer_fra_pa_pre_ba_01_til_pa_res_ba_01",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            }
+          ]
+        },
+        {
+          "navn": "pa_res_ba_01 produser kontoføringer og administrasjonspremieunderlag",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_arkivert_grunnlagsdata_fra_aktuar_til_pa_res_ba_01",
+              "versjon": "${reserveberegningGrunnlagsdataAktuarVersjon}",
+              "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "navn": "panda_reserveberegning",
+              "handling": "gruppe",
+              "gruppeAv": [
+                {
+                  "handling": "pa_res_ba_01",
+                  "modus": "panda_reserveberegning",
+                  "sisteFremskrivingsdato": "${fremskrivingsDato}",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+                  "rettighet": "panda_veldig_forenkla_rettighet",
+                  "premieprognose": {
+                    "konverteringsår": "${premieprognoseKonvertingsår}",
+                    "fremskrivingsfrekvens": "År"
+                  }
+                },
+                {
+                  "handling": "kopier_filer_fra_batch_til_batch",
+                  "fraBatch": "pa_res_ba_01",
+                  "tilBatch": "pa_fak_ba_13",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+                }
+              ]
+            },
+            {
+              "navn": "panda_administrasjonspremieunderlag",
+              "handling": "gruppe",
+              "gruppeAv": [
+                {
+                  "handling": "pa_res_ba_01",
+                  "modus": "panda_administrasjonspremieunderlag",
+                  "sisteFremskrivingsdato": "${fremskrivingsDato}",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+                  "rettighet": "panda_veldig_forenkla_rettighet"
+                },
+                {
+                  "handling": "kopier_filer_fra_batch_til_batch",
+                  "filPrefix": "administrasjonspremieunderlag",
+                  "fraBatch": "pa_res_ba_01",
+                  "tilBatch": "pa_fak_ba_05",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+                },
+                {
+                  "handling": "rydd_grunnlagsdata_for_batch",
+                  "batch": "pa_res_ba_01"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "navn": "pa_fak_ba_05 filtrer administrasjonspremieunderlag",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${avtalelisteChecksum}",
+              "prognoseVersjon": "avtaleliste",
+              "batch": "pa_fak_ba_05",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_fak_ba_05",
+              "modus": "filtrer_administrasjonspremieunderlag",
               "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-              "rettighet": "panda_veldig_forenkla_rettighet"
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_fak_ba_05"
             },
             {
               "handling": "kopier_filer_fra_batch_til_batch",
               "filPrefix": "administrasjonspremieunderlag",
-              "fraBatch": "pa_res_ba_01",
+              "fraBatch": "pa_fak_ba_05",
               "tilBatch": "pa_fak_ba_05",
               "grunnlagsdataMappe": "${grunnlagsdataMappe}"
             },
             {
-              "handling": "rydd_grunnlagsdata_for_batch",
-              "batch": "pa_res_ba_01"
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "administrasjonspremieunderlag",
+              "fraBatch": "pa_fak_ba_05",
+              "tilBatch": "pa_pre_ba_02",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
             }
           ]
-        }
-      ]
-    },
-    {
-      "navn": "pa_fak_ba_05 filtrer administrasjonspremieunderlag",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${avtalelisteChecksum}",
-          "prognoseVersjon": "avtaleliste",
-          "batch": "pa_fak_ba_05",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
         },
         {
-          "handling": "pa_fak_ba_05",
-          "modus": "filtrer_administrasjonspremieunderlag",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "validerFeilendeMedlemmer": true
+          "navn": "pa_fak_ba_05 generere administrasjonspremier",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "pa_fak_ba_05",
+              "modus": "generer_administrasjonspremier",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "bokføringsperiode": "${administrasjonspremieForSisteBokføringsperiode}",
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "administrasjonspremie",
+              "fraBatch": "pa_fak_ba_05",
+              "tilBatch": "pa_fak_ba_04",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_fak_ba_05"
+            }
+          ]
         },
         {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_fak_ba_05"
+          "navn": "pa_fak_ba_13 generere fakturerbare premiedifferanser fra kontoføringer",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "pa_fak_ba_13",
+              "modus": "generer_premiedifferanser_for_premieprognoser",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "fakturerbare_premiedifferanser",
+              "fraBatch": "pa_fak_ba_13",
+              "tilBatch": "pa_fak_ba_14",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_fak_ba_13"
+            }
+          ]
         },
         {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "administrasjonspremieunderlag",
-          "fraBatch": "pa_fak_ba_05",
-          "tilBatch": "pa_fak_ba_05",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+          "navn": "pa_fak_ba_14 generere reservetransaksjonsdifferanser for HBF AS ASA",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${avtalelisteChecksum}",
+              "prognoseVersjon": "avtaleliste",
+              "batch": "pa_fak_ba_14",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_fak_ba_14",
+              "modus": "premie_for_hbf_as_asa",
+              "grupperMedDekning": "true",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "reservetransaksjonsdifferanser_medlem",
+              "fraBatch": "pa_fak_ba_14",
+              "tilBatch": "pa_fak_ba_04",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "reservetransaksjonsdifferanser_medlem",
+              "fraBatch": "pa_fak_ba_14",
+              "tilBatch": "pa_pre_ba_02",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_fak_ba_14"
+            }
+          ]
         },
         {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "administrasjonspremieunderlag",
-          "fraBatch": "pa_fak_ba_05",
-          "tilBatch": "pa_pre_ba_02",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        }
-      ]
-    },
-    {
-      "navn": "pa_fak_ba_05 generere administrasjonspremier",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "pa_fak_ba_05",
-          "modus": "generer_administrasjonspremier",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "bokføringsperiode": "${administrasjonspremieForSisteBokføringsperiode}",
-          "validerFeilendeMedlemmer": true
+          "navn": "pa_fak_ba_04 premieprognoser for HBF AS ASA",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${solvenspremieChecksum}",
+              "prognoseVersjon": "solvenspremie",
+              "batch": "pa_fak_ba_04",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_fak_ba_04",
+              "modus": "premieprognoser_for_hbf_as_asa",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "prognoseAar": "${prognoseAar}",
+              "premiemodell": "HBF_AS/ASA",
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "premieprognoser",
+              "fraBatch": "pa_fak_ba_04",
+              "tilBatch": "pa_pre_ba_02",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_fak_ba_04"
+            }
+          ]
         },
         {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "administrasjonspremie",
-          "fraBatch": "pa_fak_ba_05",
-          "tilBatch": "pa_fak_ba_04",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_fak_ba_05"
-        }
-      ]
-    },
-    {
-      "navn": "pa_fak_ba_13 generere fakturerbare premiedifferanser fra kontoføringer",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "pa_fak_ba_13",
-          "modus": "generer_premiedifferanser_for_premieprognoser",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "validerFeilendeMedlemmer": true
-        },
-        {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "fakturerbare_premiedifferanser",
-          "fraBatch": "pa_fak_ba_13",
-          "tilBatch": "pa_fak_ba_14",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_fak_ba_13"
-        }
-      ]
-    },
-    {
-      "navn": "pa_fak_ba_14 generere reservetransaksjonsdifferanser for HBF AS ASA",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${avtalelisteChecksum}",
-          "prognoseVersjon": "avtaleliste",
-          "batch": "pa_fak_ba_14",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "pa_fak_ba_14",
-          "modus": "premie_for_hbf_as_asa",
-          "grupperMedDekning": "true",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "validerFeilendeMedlemmer": true
-        },
-        {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "reservetransaksjonsdifferanser_medlem",
-          "fraBatch": "pa_fak_ba_14",
-          "tilBatch": "pa_fak_ba_04",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "reservetransaksjonsdifferanser_medlem",
-          "fraBatch": "pa_fak_ba_14",
-          "tilBatch": "pa_pre_ba_02",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_fak_ba_14"
-        }
-      ]
-    },
-    {
-      "navn": "pa_fak_ba_04 premieprognoser for HBF AS ASA",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${solvenspremieChecksum}",
-          "prognoseVersjon": "solvenspremie",
-          "batch": "pa_fak_ba_04",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "pa_fak_ba_04",
-          "modus": "premieprognoser_for_hbf_as_asa",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "prognoseAar": "${prognoseAar}",
-          "premiemodell": "HBF_AS/ASA",
-          "validerFeilendeMedlemmer": true
-        },
-        {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "premieprognoser",
-          "fraBatch": "pa_fak_ba_04",
-          "tilBatch": "pa_pre_ba_02",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_fak_ba_04"
-        }
-      ]
-    },
-    {
-      "navn": "pa_pre_ba_02 last opp data for premieprognoser",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${avtalelisteChecksum}",
-          "prognoseVersjon": "avtaleliste",
-          "batch": "pa_pre_ba_02",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "prognosejustering",
-          "prognoseVersjon": "${prognosejusteringChecksum}",
-          "batch": "pa_pre_ba_02",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "ignorertInstruksjon": "${ignorerPrognosejusteringInstruksjon}"
-        },
-        {
-          "handling": "pa_pre_ba_02",
-          "modus": "premieprognoser_avtale",
-          "kjøringsId": "${kjøringsId}",
-          "filnavn": "premieprognoser",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "pa_pre_ba_02",
-          "modus": "premieprognoser_medlem",
-          "kjøringsId": "${kjøringsId}",
-          "filnavn": "reservetransaksjonsdifferanser_medlem",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "pa_pre_ba_02",
-          "modus": "premieprognoser_avtaleliste",
-          "kjøringsId": "${kjøringsId}",
-          "filnavn": "avtaleliste_hbf_as_asa",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "pa_pre_ba_02",
-          "modus": "administrasjonspremieunderlag",
-          "kjøringsId": "${kjøringsId}",
-          "filnavn": "administrasjonspremieunderlag",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "handling": "pa_pre_ba_02",
-          "modus": "prognosejustering",
-          "kjøringsId": "${kjøringsId}",
-          "filnavn": "prognosejustering",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "ignorertInstruksjon": "${ignorerPrognosejusteringInstruksjon}"
-        },
-        {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_pre_ba_02"
+          "navn": "pa_pre_ba_02 last opp data for premieprognoser",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${avtalelisteChecksum}",
+              "prognoseVersjon": "avtaleliste",
+              "batch": "pa_pre_ba_02",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "prognosejustering",
+              "prognoseVersjon": "${prognosejusteringChecksum}",
+              "batch": "pa_pre_ba_02",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "ignorertInstruksjon": "${ignorerPrognosejusteringInstruksjon}"
+            },
+            {
+              "handling": "pa_pre_ba_02",
+              "modus": "premieprognoser_avtale",
+              "kjøringsId": "${kjøringsId}",
+              "filnavn": "premieprognoser",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_pre_ba_02",
+              "modus": "premieprognoser_medlem",
+              "kjøringsId": "${kjøringsId}",
+              "filnavn": "reservetransaksjonsdifferanser_medlem",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_pre_ba_02",
+              "modus": "premieprognoser_avtaleliste",
+              "kjøringsId": "${kjøringsId}",
+              "filnavn": "avtaleliste_hbf_as_asa",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_pre_ba_02",
+              "modus": "administrasjonspremieunderlag",
+              "kjøringsId": "${kjøringsId}",
+              "filnavn": "administrasjonspremieunderlag",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_pre_ba_02",
+              "modus": "prognosejustering",
+              "kjøringsId": "${kjøringsId}",
+              "filnavn": "prognosejustering",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "ignorertInstruksjon": "${ignorerPrognosejusteringInstruksjon}"
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_pre_ba_02"
+            }
+          ]
         }
       ]
     },

--- a/maler/premieprognose/premieprognose_as_asa_solvens.json
+++ b/maler/premieprognose/premieprognose_as_asa_solvens.json
@@ -142,6 +142,11 @@
               "handling": "gruppe",
               "gruppeAv": [
                 {
+                  "handling": "kopier_arkivert_grunnlagsdata_fra_aktuar_til_pa_res_ba_01",
+                  "versjon": "${reserveberegningGrunnlagsdataAktuarVersjon}",
+                  "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}"
+                },
+                {
                   "handling": "pa_res_ba_01",
                   "modus": "panda_reserveberegning",
                   "sisteFremskrivingsdato": "${fremskrivingsDato}",

--- a/maler/premieprognose/premieprognose_as_asa_solvens.json
+++ b/maler/premieprognose/premieprognose_as_asa_solvens.json
@@ -10,13 +10,10 @@
     "grunnlagsdataMappe": "#{grunnlagsdatamappeNå}",
     "fraGrunnlagsdataMappe": "<grunnlagsdata_0000-00-00_00-00-00-00>",
     "kjøringsId": "#{genererUUID}",
-
     "prognoseAar": "<yyyy>",
-
     "premieprognoseKonvertingsår": "<yyyy>",
     "reserveberegningGrunnlagsdataAktuarVersjon": "<N>",
     "fremskrivingsDato": "<yyyy.MM.dd>",
-
     "avtalelisteChecksum": "<avtalelisteChecksum>",
     "opprettNyAvtaleChecksum": "<opprettNyAvtaleChecksum>",
     "ignorerOpprettNyAvtaleInstruksjon": "<true|false>",
@@ -100,165 +97,222 @@
       ]
     },
     {
-      "navn": "manipuler prognosedata",
+      "navn": "Første kjøring for å utlede målytelse fra reserveberegning",
       "handling": "gruppe",
       "gruppeAv": [
         {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_pre_ba_01"
-        },
-        {
-          "handling": "kopier_grunnlagsdata_fra_arkiv_til_batch",
-          "fraGrunnlagsdataMappe": "${fraGrunnlagsdataMappe}",
-          "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "fraBatch": "pa_res_ba_02",
-          "tilBatch": "pa_pre_ba_01"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${avtalelisteChecksum}",
-          "prognoseVersjon": "avtaleliste",
-          "batch": "pa_pre_ba_01"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_ny_avtale",
-          "prognoseVersjon": "${opprettNyAvtaleChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettNyAvtaleInstruksjon}"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_avtalebytte",
-          "prognoseVersjon": "${opprettAvtalebytteChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettAvtalebytteInstruksjon}"
-
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_avtalebytte_medlem",
-          "prognoseVersjon": "${opprettAvtalebytteMedlemChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettAvtalebytteMedlemInstruksjon}"
-        },
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "opprett_sluttmelding",
-          "prognoseVersjon": "${opprettSluttmeldingChecksum}",
-          "batch": "pa_pre_ba_01",
-          "ignorertInstruksjon": "${ignorerOpprettSluttmeldingInstruksjon}"
-        },
-        {
-          "handling": "pa_pre_ba_01",
-          "manipulatorer": "${manipulatorer}"
-        },
-        {
-          "handling": "kopier_filer_fra_pa_pre_ba_01_til_pa_res_ba_01",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        }
-      ]
-    },
-    {
-      "navn": "pa_res_ba_01 produser kontoføringer",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_arkivert_grunnlagsdata_fra_aktuar_til_pa_res_ba_01",
-          "versjon": "${reserveberegningGrunnlagsdataAktuarVersjon}",
-          "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}"
-        },
-        {
-          "navn": "panda_reserveberegning",
+          "navn": "manipuler prognosedata",
           "handling": "gruppe",
           "gruppeAv": [
             {
-              "handling": "pa_res_ba_01",
-              "modus": "panda_reserveberegning",
-              "sisteFremskrivingsdato": "${fremskrivingsDato}",
-              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-              "rettighet": "panda_veldig_forenkla_rettighet",
-              "premieprognose": {
-                "konverteringsår": "${premieprognoseKonvertingsår}",
-                "fremskrivingsfrekvens": "År"
-              }
+              "handling": "kopier_grunnlagsdata_fra_arkiv_til_batch",
+              "fraGrunnlagsdataMappe": "${fraGrunnlagsdataMappe}",
+              "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "fraBatch": "pa_res_ba_02",
+              "tilBatch": "pa_pre_ba_01"
             },
             {
-              "handling": "kopier_filer_fra_batch_til_batch",
-              "fraBatch": "pa_res_ba_01",
-              "tilBatch": "pa_fak_ba_13",
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${avtalelisteChecksum}",
+              "prognoseVersjon": "avtaleliste",
+              "batch": "pa_pre_ba_01"
+            },
+            {
+              "handling": "pa_pre_ba_01",
+              "manipulatorer": [
+                {
+                  "navn": "filtrer_medlemsbestand",
+                  "fraFil": "avtaleliste_hbf_as_asa.csv"
+                }
+              ]
+            },
+            {
+              "handling": "kopier_filer_fra_pa_pre_ba_01_til_pa_res_ba_01",
               "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            }
+          ]
+        },
+        {
+          "navn": "pa_res_ba_01 produser kontoføringer",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "navn": "panda_reserveberegning",
+              "handling": "gruppe",
+              "gruppeAv": [
+                {
+                  "handling": "pa_res_ba_01",
+                  "modus": "panda_reserveberegning",
+                  "sisteFremskrivingsdato": "${fremskrivingsDato}",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+                  "rettighet": "panda_veldig_forenkla_rettighet",
+                  "premieprognose": {
+                    "konverteringsår": "${premieprognoseKonvertingsår}",
+                    "fremskrivingsfrekvens": "År"
+                  }
+                },
+                {
+                  "handling": "legg_kontofoering_i_medlemsdata_for_manipulering",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+                },
+                {
+                  "handling": "rydd_grunnlagsdata_for_batch",
+                  "batch": "pa_res_ba_01"
+                }
+              ]
             }
           ]
         }
       ]
     },
     {
-      "navn": "pa_fak_ba_13 generere fakturerbare premiedifferanser fra kontoføringer",
+      "navn": "Andre kjøring for premieprognoser for AS/ASA",
       "handling": "gruppe",
       "gruppeAv": [
         {
-          "handling": "pa_fak_ba_13",
-          "modus": "generer_premiedifferanser_for_premieprognoser",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "validerFeilendeMedlemmer": true
+          "navn": "manipuler prognosedata",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_ny_avtale",
+              "prognoseVersjon": "${opprettNyAvtaleChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettNyAvtaleInstruksjon}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_avtalebytte",
+              "prognoseVersjon": "${opprettAvtalebytteChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettAvtalebytteInstruksjon}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_avtalebytte_medlem",
+              "prognoseVersjon": "${opprettAvtalebytteMedlemChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettAvtalebytteMedlemInstruksjon}"
+            },
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "opprett_sluttmelding",
+              "prognoseVersjon": "${opprettSluttmeldingChecksum}",
+              "batch": "pa_pre_ba_01",
+              "ignorertInstruksjon": "${ignorerOpprettSluttmeldingInstruksjon}"
+            },
+            {
+              "handling": "pa_pre_ba_01",
+              "manipulatorer": "${manipulatorer}"
+            },
+            {
+              "handling": "kopier_filer_fra_pa_pre_ba_01_til_pa_res_ba_01",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            }
+          ]
         },
         {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "fakturerbare_premiedifferanser",
-          "fraBatch": "pa_fak_ba_13",
-          "tilBatch": "pa_fak_ba_14",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+          "navn": "pa_res_ba_01 produser kontoføringer",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_arkivert_grunnlagsdata_fra_aktuar_til_pa_res_ba_01",
+              "versjon": "${reserveberegningGrunnlagsdataAktuarVersjon}",
+              "tilGrunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "navn": "panda_reserveberegning",
+              "handling": "gruppe",
+              "gruppeAv": [
+                {
+                  "handling": "pa_res_ba_01",
+                  "modus": "panda_reserveberegning",
+                  "sisteFremskrivingsdato": "${fremskrivingsDato}",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+                  "rettighet": "panda_veldig_forenkla_rettighet",
+                  "premieprognose": {
+                    "konverteringsår": "${premieprognoseKonvertingsår}",
+                    "fremskrivingsfrekvens": "År"
+                  }
+                },
+                {
+                  "handling": "kopier_filer_fra_batch_til_batch",
+                  "fraBatch": "pa_res_ba_01",
+                  "tilBatch": "pa_fak_ba_13",
+                  "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+                }
+              ]
+            }
+          ]
         },
         {
-          "handling": "rydd_grunnlagsdata_for_batch",
-          "batch": "pa_res_ba_01"
-        }
-      ]
-    },
-    {
-      "navn": "pa_fak_ba_14 generere reservetransaksjonsdifferanser for HBF AS ASA",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "kopier_filer_fra_aktuar_til_batch",
-          "premiemodell": "premieprognose",
-          "periode": "${avtalelisteChecksum}",
-          "prognoseVersjon": "avtaleliste",
-          "batch": "pa_fak_ba_14",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+          "navn": "pa_fak_ba_13 generere fakturerbare premiedifferanser fra kontoføringer",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "pa_fak_ba_13",
+              "modus": "generer_premiedifferanser_for_premieprognoser",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "fakturerbare_premiedifferanser",
+              "fraBatch": "pa_fak_ba_13",
+              "tilBatch": "pa_fak_ba_14",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "rydd_grunnlagsdata_for_batch",
+              "batch": "pa_res_ba_01"
+            }
+          ]
         },
         {
-          "handling": "pa_fak_ba_14",
-          "modus": "premie_for_hbf_as_asa",
-          "grupperMedDekning": "true",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}",
-          "validerFeilendeMedlemmer": true
+          "navn": "pa_fak_ba_14 generere reservetransaksjonsdifferanser for HBF AS ASA",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "kopier_filer_fra_aktuar_til_batch",
+              "premiemodell": "premieprognose",
+              "periode": "${avtalelisteChecksum}",
+              "prognoseVersjon": "avtaleliste",
+              "batch": "pa_fak_ba_14",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            },
+            {
+              "handling": "pa_fak_ba_14",
+              "modus": "premie_for_hbf_as_asa",
+              "grupperMedDekning": "true",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}",
+              "validerFeilendeMedlemmer": true
+            },
+            {
+              "handling": "kopier_filer_fra_batch_til_batch",
+              "filPrefix": "reservetransaksjonsdifferanser_medlem",
+              "fraBatch": "pa_fak_ba_14",
+              "tilBatch": "pa_pre_ba_02",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            }
+          ]
         },
         {
-          "handling": "kopier_filer_fra_batch_til_batch",
-          "filPrefix": "reservetransaksjonsdifferanser_medlem",
-          "fraBatch": "pa_fak_ba_14",
-          "tilBatch": "pa_pre_ba_02",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
-        }
-      ]
-    },
-    {
-      "navn": "pa_pre_ba_02 last opp reservetransaksjonsdifferanser",
-      "handling": "gruppe",
-      "gruppeAv": [
-        {
-          "handling": "pa_pre_ba_02",
-          "modus": "premieprognoser_medlem",
-          "kjøringsId": "${kjøringsId}",
-          "filnavn": "reservetransaksjonsdifferanser_medlem",
-          "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+          "navn": "pa_pre_ba_02 last opp reservetransaksjonsdifferanser",
+          "handling": "gruppe",
+          "gruppeAv": [
+            {
+              "handling": "pa_pre_ba_02",
+              "modus": "premieprognoser_medlem",
+              "kjøringsId": "${kjøringsId}",
+              "filnavn": "reservetransaksjonsdifferanser_medlem",
+              "grunnlagsdataMappe": "${grunnlagsdataMappe}"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
- Legger inn første kjøring for å utlede målytelse som benyttes i pa-pre-ba-01 manipulator opprett vedtak